### PR TITLE
[UPGRADE] Now search for near locations on AutcompleteLocations

### DIFF
--- a/app/models/autocomplete_locations/autocomplete_location.rb
+++ b/app/models/autocomplete_locations/autocomplete_location.rb
@@ -1,6 +1,8 @@
 module AutocompleteLocations
   class AutocompleteLocation < ActiveRecord::Base
 
+    reverse_geocoded_by :latitude, :longitude
+
     self.table_name = 'autocomplete_locations'
 
     scope :at_lat_long, -> (lat, long) { where(["abs(autocomplete_locations.latitude-#{lat}) <= 1e-4 AND abs(autocomplete_locations.longitude-#{long}) <= 1e-4"]) }

--- a/lib/autocomplete_locations/version.rb
+++ b/lib/autocomplete_locations/version.rb
@@ -1,3 +1,3 @@
 module AutocompleteLocations
-  VERSION = '0.1.6'
+  VERSION = '0.1.7'
 end


### PR DESCRIPTION
Added reverse geocoding for model - AutcompleteLocation. Now you can do queries like `AutocompleteLocations::AutocompleteLocation.near("<latitude>,<longitude>")`