### PR TITLE
[FIX] Factories updated removed deprecated warnings

### DIFF
--- a/lib/autocomplete_locations/factories.rb
+++ b/lib/autocomplete_locations/factories.rb
@@ -3,11 +3,11 @@ require_relative '../../app/models/autocomplete_locations/autocomplete_location'
 FactoryBot.define do
   factory :autocomplete_locations, :class => AutocompleteLocations::AutocompleteLocation do
     sequence(:id) {|n| n}
-    state 15
-    city_id 1
-    city "Bangalore"
-    latitude 12.9716
-    longitude 77.5946
-    default_city true
+    state { 15 }
+    city_id { 1 }
+    city { "Bangalore" }
+    latitude { 12.9716 }
+    longitude { 77.5946 }
+    default_city { true }
   end
 end

--- a/lib/autocomplete_locations/version.rb
+++ b/lib/autocomplete_locations/version.rb
@@ -1,3 +1,3 @@
 module AutocompleteLocations
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end


### PR DESCRIPTION
*DEPRECATION WARNING* : Static attributes will be removed in FactoryBot 5.0. Please use dynamic attributes instead by wrapping the attribute value in a block.

Added blocks for factories.